### PR TITLE
fix: clear previous exhibition's artworks when switching virtual exhi…

### DIFF
--- a/src/hooks/useLoadExhibitionArtworks.ts
+++ b/src/hooks/useLoadExhibitionArtworks.ts
@@ -6,7 +6,7 @@ import {
   mapToArtwork,
   mapToArtworkPosition,
 } from '@/lib/exhibitionArtworkMapper'
-import { restoreArtwork } from '@/redux/slices/artworkSlice'
+import { resetArtworks, restoreArtwork } from '@/redux/slices/artworkSlice'
 import { createArtworkPosition } from '@/redux/slices/exhibitionSlice'
 
 /**
@@ -60,6 +60,13 @@ export const useLoadExhibitionArtworks = (exhibitionId: string | undefined, mode
     const loadArtworks = async () => {
       setLoading(true)
       setImagesLoading(true)
+      // Clear artworks from any previous exhibition before loading the new
+      // ones. Without this, navigating exhibition A → exhibition B leaves
+      // A's artworks in `state.byId` and the scene renders both sets
+      // mixed in the same room. Same-exhibition reload is short-circuited
+      // by the `loadedExhibitionId.current === exhibitionId` check above,
+      // so this only fires on a genuine exhibition switch.
+      dispatch(resetArtworks())
       try {
         const modeParam = mode ? `&mode=${mode}` : ''
         const response = await fetch(

--- a/src/redux/slices/exhibitionSlice.ts
+++ b/src/redux/slices/exhibitionSlice.ts
@@ -125,9 +125,15 @@ const exhibitionSlice = createSlice({
     },
 
     setExhibition: (state: TExhibitionWithHistory, action: PayloadAction<TExhibition>) => {
-      // Preserve existing artwork positions if they've been loaded
+      // Preserve existing artwork positions only when re-setting the SAME
+      // exhibition (e.g., RTK Query refetch). Switching to a different
+      // exhibition must drop the previous one's positions — otherwise
+      // both exhibitions' artworks render mixed in the same room.
+      const isSameExhibition = state.id === action.payload.id
       const preservePositions =
-        state.allExhibitionArtworkIds && state.allExhibitionArtworkIds.length > 0
+        isSameExhibition &&
+        state.allExhibitionArtworkIds &&
+        state.allExhibitionArtworkIds.length > 0
       return {
         ...action.payload,
         ...(preservePositions


### PR DESCRIPTION
…bitions

Switching from one virtual exhibition to another rendered both sets of artworks mixed in the same room.

Two reducers were preserving cross-exhibition state:
- artworkSlice.restoreArtwork only added; never cleared. Loading exhibition B left A's artworks in state.byId.
- exhibitionSlice.setExhibition preserved positions whenever any existed — even when switching to a different exhibition ID.

Fix:
- useLoadExhibitionArtworks dispatches resetArtworks() before loading a new exhibition's data. The existing same-exhibition short-circuit prevents this firing on a re-mount of the same exhibition.
- setExhibition only preserves positions when state.id matches the incoming payload's id (genuine same-exhibition refetch).