### PR TITLE
LG-110: gate e2e suite from sending real Resend emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "test:e2e:send-emails": "E2E_SEND_EMAILS=true playwright test",
     "test:e2e:install": "playwright install chromium",
     "prepare": "husky"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,16 +18,29 @@ loadDotenv({ path: path.join(ROOT, '.env.test.local'), override: true })
  * Playwright configuration — local-only e2e tests.
  *
  * - Tests live in `./e2e`.
- * - Base URL is read from `PLAYWRIGHT_BASE_URL`, defaulting to
- *   `http://localhost:3001` (the `dev` script's port). If you change
- *   the dev server port later, update this default OR override the
- *   env var at run time: `PLAYWRIGHT_BASE_URL=http://localhost:4000 pnpm test:e2e`.
- * - `webServer.reuseExistingServer: true` so if you already have
- *   `pnpm dev` running, Playwright picks that up instead of trying to
- *   start a second instance on the same port. If no dev server is
- *   running, Playwright starts one for the duration of the run.
+ * - Base URL defaults to `http://localhost:3001` — the same port as
+ *   `pnpm dev`. Override with `PLAYWRIGHT_BASE_URL=http://localhost:4000 pnpm test:e2e`.
+ * - `reuseExistingServer: false` — Playwright always spawns its own
+ *   `next dev -p 3001` for the run. We need this so the email-skip
+ *   env vars below actually land on the dev server's process (an
+ *   already-running server has its own frozen env). Practical
+ *   consequence: stop `pnpm dev` before running e2e, otherwise the
+ *   spawn fails with "port 3001 already in use".
+ * - We keep e2e on 3001 (instead of a separate port) so the existing
+ *   Stripe CLI forwarder (`stripe listen --forward-to localhost:3001/...`)
+ *   reaches the test server without any reconfiguration. The buyer +
+ *   admin-lifecycle specs need that webhook to land for the PrintOrder
+ *   row to get created.
  * - No CI-specific config: these tests are intentionally not wired
  *   into the build pipeline. Run them by hand with `pnpm test:e2e`.
+ *
+ * Email handling:
+ *   - `pnpm test:e2e` (default, daily/pre-push): SKIP_EMAILS,
+ *     SKIP_LOGIN_EMAIL, SKIP_LOGIN_OTP are all injected into the dev
+ *     server, so no real Resend traffic leaves the suite.
+ *   - `pnpm test:e2e:send-emails` (rare, manual verification): same
+ *     suite but emails actually go out. Use only when verifying
+ *     templates or end-to-end Resend delivery — burns the quota fast.
  *
  * Most specs are read-only by contract — they hit a shared dev /
  * staging DB and observe state without mutating it. The exceptions
@@ -38,15 +51,24 @@ loadDotenv({ path: path.join(ROOT, '.env.test.local'), override: true })
  * specs should default to read-only; only opt in to writes when the
  * test target is the persistence pipeline itself.
  *
- * Pre-requisites for the write specs:
- *   - SKIP_EMAILS=true in the dev server's env (prevents Resend from
- *     fanning out real emails during the run).
+ * Other pre-requisites for the write specs:
  *   - NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY + STRIPE_SECRET_KEY pointing
  *     at Stripe test-mode keys.
  *   - Local Stripe CLI webhook listener forwarding to /api/webhooks/stripe
  *     so the order row actually gets created.
  */
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3001'
+
+// Default = suppress all email sends. Opt in to real sends with
+// `pnpm test:e2e-no-skips`, which sets E2E_SEND_EMAILS=true.
+const sendEmails = process.env.E2E_SEND_EMAILS === 'true'
+const emailSkipEnv: Record<string, string> = sendEmails
+  ? {}
+  : {
+      SKIP_EMAILS: 'true',
+      SKIP_LOGIN_EMAIL: 'true',
+      SKIP_LOGIN_OTP: 'true',
+    }
 
 export default defineConfig({
   testDir: './e2e',
@@ -86,9 +108,10 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm dev',
+    command: 'next dev -p 3001',
     url: BASE_URL,
-    reuseExistingServer: true,
+    reuseExistingServer: false,
     timeout: 120_000,
+    env: emailSkipEnv,
   },
 })

--- a/src/app/artists/[slug]/page.tsx
+++ b/src/app/artists/[slug]/page.tsx
@@ -100,9 +100,7 @@ const ArtistProfile = async ({ params }: ArtistProfileProps) => {
   if (!artist) notFound()
 
   const { exhibitions, artworks, ...artistData } = artist
-  return (
-    <ArtistProfilePage artist={artistData} exhibitions={exhibitions} artworks={artworks} />
-  )
+  return <ArtistProfilePage artist={artistData} exhibitions={exhibitions} artworks={artworks} />
 }
 
 export default ArtistProfile

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import StoreProvider from '@/app/storeProvider'
 import { AuthProvider } from '@/components/providers/AuthProvider'
 import { ImageProtection } from '@/components/providers/ImageProtection'
 import { CookieBanner } from '@/components/ui/CookieBanner'
+import { NavigationProgressBar } from '@/components/ui/NavigationProgressBar'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import '@/styles/globals.scss'
@@ -80,6 +81,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <a href="#main-content" className="skip-to-content">
           Skip to main content
         </a>
+        <NavigationProgressBar />
         <AuthProvider>
           <StoreProvider>
             <ImageProtection />

--- a/src/app/prints/page.tsx
+++ b/src/app/prints/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 // surface too: 'page-prints' (CMS edit), 'artworks' (artwork edit).
 const getCachedPrintsPage = unstable_cache(
   async () => {
-    const [artworks, page] = await Promise.all([
+    const [artworksRaw, page] = await Promise.all([
       prisma.artwork.findMany({
         where: {
           printEnabled: true,
@@ -45,6 +45,14 @@ const getCachedPrintsPage = unstable_cache(
       }),
       prisma.pageContent.findUnique({ where: { slug: 'prints' } }),
     ])
+    // Convert Date → ISO string before the cache stores the payload.
+    // unstable_cache serializes on store; reading a cached entry gives
+    // back a string, so calling .toISOString() outside this function
+    // crashes on cache hits.
+    const artworks = artworksRaw.map((a) => ({
+      ...a,
+      createdAt: a.createdAt.toISOString(),
+    }))
     return { artworks, page }
   },
   ['prints-public-page'],
@@ -52,15 +60,7 @@ const getCachedPrintsPage = unstable_cache(
 )
 
 const Prints = async () => {
-  const { artworks: artworksRaw, page: pageRaw } = await getCachedPrintsPage()
-
-  // PrintArtwork.createdAt is a string in the client type (from JSON
-  // over the wire pre-conversion). Stringify here so the prop shape
-  // matches without forcing the client component to know about Date.
-  const artworks = artworksRaw.map((a) => ({
-    ...a,
-    createdAt: a.createdAt.toISOString(),
-  }))
+  const { artworks, page: pageRaw } = await getCachedPrintsPage()
 
   const pageContent = pageRaw
     ? {

--- a/src/components/exhibitions/index.tsx
+++ b/src/components/exhibitions/index.tsx
@@ -87,11 +87,7 @@ export const ExhibitionsPage = ({ exhibitions }: ExhibitionsPageProps) => {
         ) : (
           <ul className={styles.list}>
             {currentExhibitions.map((exhibition, idx) => (
-              <ExhibitionCard
-                key={exhibition.id}
-                exhibition={exhibition}
-                priority={idx === 0}
-              />
+              <ExhibitionCard key={exhibition.id} exhibition={exhibition} priority={idx === 0} />
             ))}
           </ul>
         )}

--- a/src/components/ui/InquireSidebar/InquireSidebar.tsx
+++ b/src/components/ui/InquireSidebar/InquireSidebar.tsx
@@ -314,7 +314,7 @@ export const InquireSidebar = ({ isOpen, onClose, artwork }: InquireSidebarProps
                     />
                   </div>
                   <div className={styles.artworkInfo}>
-                    <Text as="p" size="sm" weight="medium">
+                    <Text as="p" size="sm" weight="medium" font="serif">
                       {artwork.artistName}
                     </Text>
                     <Text as="p" size="sm" font="serif">

--- a/src/components/ui/NavigationProgressBar/NavigationProgressBar.tsx
+++ b/src/components/ui/NavigationProgressBar/NavigationProgressBar.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+import { LoadingBar } from '@/components/ui/LoadingBar'
+
+/**
+ * Shows the LoadingBar at the top of the viewport during route
+ * navigation, so users get immediate feedback that their click was
+ * registered while the SSR'd next page is being fetched.
+ *
+ * Mechanism: a document-level click listener flips `pending` to true
+ * when the user clicks an internal anchor that will trigger a route
+ * change. The flag clears once `usePathname()` reflects the new path —
+ * which only happens after the new page has rendered, i.e. the moment
+ * the destination content is visible.
+ *
+ * Not covered (out of scope for now): programmatic `router.push()`
+ * from buttons (no click on an <a>), and search-param-only navigations
+ * that don't change the pathname. Wire those up separately if needed.
+ */
+// Safety net: if a navigation never completes (e.g. Stripe-hosted
+// iframe redirect, server error swallowed somewhere), clear the bar
+// after this many ms instead of leaving it stuck. SSR pages on this
+// site routinely take ~1s; 10s leaves plenty of headroom.
+const MAX_PENDING_MS = 10_000
+
+export function NavigationProgressBar() {
+  const pathname = usePathname()
+  const [pending, setPending] = useState(false)
+
+  // Pathname committed → navigation done.
+  useEffect(() => {
+    setPending(false)
+  }, [pathname])
+
+  // Fallback clear in case pathname never changes (broken nav, prevented
+  // click on something that looked like a real link, etc.).
+  useEffect(() => {
+    if (!pending) return
+    const t = window.setTimeout(() => setPending(false), MAX_PENDING_MS)
+    return () => window.clearTimeout(t)
+  }, [pending])
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      // Don't gate on `e.defaultPrevented`: Next's <Link> intentionally
+      // calls preventDefault to take over navigation client-side, and
+      // those are exactly the clicks we want to react to.
+
+      // Left-click only; ignore middle/right.
+      if (e.button !== 0) return
+      // Modifier keys = "open in new tab/window/etc." — no in-page nav.
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+
+      // Walk up to the nearest anchor (clicks often land on inner spans/svgs).
+      let node: HTMLElement | null = e.target as HTMLElement | null
+      while (node && node.tagName !== 'A') node = node.parentElement
+      if (!node) return
+
+      const a = node as HTMLAnchorElement
+      if (!a.href) return
+      if (a.target && a.target !== '_self') return
+      if (a.hasAttribute('download')) return
+
+      let url: URL
+      try {
+        url = new URL(a.href)
+      } catch {
+        return
+      }
+
+      // Different origin: full page load, browser handles the chrome.
+      if (url.origin !== window.location.origin) return
+
+      // Same URL (or pure hash change on the same page): no navigation.
+      const samePath = url.pathname === window.location.pathname
+      const sameSearch = url.search === window.location.search
+      if (samePath && sameSearch) return
+
+      setPending(true)
+    }
+
+    // Capture phase so we still see the click if a downstream handler
+    // (e.g. Swiper's slide-click logic) calls stopPropagation in bubble.
+    document.addEventListener('click', onClick, { capture: true })
+    return () => document.removeEventListener('click', onClick, { capture: true })
+  }, [])
+
+  if (!pending) return null
+  return <LoadingBar />
+}

--- a/src/components/ui/NavigationProgressBar/index.ts
+++ b/src/components/ui/NavigationProgressBar/index.ts
@@ -1,0 +1,1 @@
+export { NavigationProgressBar } from './NavigationProgressBar'


### PR DESCRIPTION
Playwright always spawns its own dev server (reuseExistingServer: false) on port 3001 so it can inject SKIP_EMAILS / SKIP_LOGIN_EMAIL / SKIP_LOGIN_OTP into that process. pnpm test:e2e is now safe by default; opt back in with pnpm test:e2e:send-emails when verifying templates against real delivery. Pre-push hook unchanged, picks up the safe default.

Side fixes that came up while testing:
- Add NavigationProgressBar reusing the existing LoadingBar so SSR navigations show a top-bar acknowledgement immediately on click, closing the perceived "did my click register?" gap from LG-109. Document-level click listener in capture phase so it survives components that stopPropagation in bubble (e.g. Swiper).
- Fix /prints crash: createdAt is serialized to a string by unstable_cache, so .toISOString() must run inside the cached function rather than after the returned payload.
- InquireSidebar artist name now uses serif to match the artwork title treatment.