### PR TITLE
LG-112: cut CLS sources + lift public profile pages off the client bu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -9,24 +9,33 @@ import localFont from 'next/font/local'
  * Body font - Used for: text, navigation, forms, labels, lists, UI elements
  * Current: Lato
  * To change: Replace Lato with any Google font and update the variable name if needed
+ *
+ * `display: 'optional'` — the browser waits ~100ms for the font; if it
+ * hasn't arrived, the size-adjusted fallback is used for the whole
+ * pageview, eliminating font-swap CLS. Trade-off: slow-connection
+ * visitors may not see the brand font on first paint.
  */
 export const bodyFont = Lato({
   subsets: ['latin'],
   weight: ['300', '400', '700'],
   variable: '--font-sans',
-  display: 'swap',
+  display: 'optional',
 })
 
 /**
  * Heading font - Used for: h1, h2, h3, h4, h5, h6
  * Current: EB Garamond
  * To change: Replace EB_Garamond with any Google font
+ *
+ * `display: 'optional'` — see note on bodyFont. Headings are the most
+ * visible font-swap CLS source because heading sizes amplify metric
+ * differences between fallback and webfont.
  */
 export const headingFont = EB_Garamond({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
   variable: '--font-serif',
-  display: 'swap',
+  display: 'optional',
 })
 
 /**

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
       lang="en"
       className={`${bodyFont.variable} ${headingFont.variable} ${dashboardFont.variable} ${wallFont1.variable} ${wallFont2.variable} ${wallFont3.variable} ${wallFont4.variable} ${wallFont5.variable} ${wallFont6.variable}`}
     >
+      <head>
+        {/* Preconnect to the image CDN so the hero image's TLS handshake
+            overlaps with HTML parsing instead of blocking LCP. */}
+        <link rel="preconnect" href="https://assets.theartroom.gallery" crossOrigin="anonymous" />
+      </head>
       <body>
         <script
           type="application/ld+json"

--- a/src/components/artists/profile/index.tsx
+++ b/src/components/artists/profile/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ProtectedImage } from '@/components/ui/ProtectedImage/ProtectedImage'
 
 import { ArtworkGrid } from '@/components/artwork/ArtworkGrid'

--- a/src/components/artwork/ArtworkGrid/ArtworkGrid.module.scss
+++ b/src/components/artwork/ArtworkGrid/ArtworkGrid.module.scss
@@ -41,7 +41,10 @@
   width: 100%;
   height: auto;
   object-fit: contain;
-  max-height: 600px;
+  // No `max-height` cap — let the per-tile width/height from next/image
+  // drive the reserved slot. A `max-height` clamp at paint time made the
+  // rendered height differ from the placeholder slot for tall portrait
+  // works, which showed up as CLS on every grid render.
 }
 
 .placeholder {

--- a/src/components/exhibitions/profile/EnterExhibitionButton.tsx
+++ b/src/components/exhibitions/profile/EnterExhibitionButton.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { ArrowRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/Button'
+import { ICON_STROKE_WIDTH } from '@/lib/iconConfig'
+
+interface EnterExhibitionButtonProps {
+  artistSlug: string
+  exhibitionSlug: string
+  visitUrl: string
+  className?: string
+}
+
+// Carved out as a client island so the surrounding profile page can
+// stay a server component. The only client-side work here is the
+// sessionStorage write that lets the visit page know we came from a
+// gallery / profile context (for return-URL behaviour).
+export const EnterExhibitionButton = ({
+  artistSlug,
+  exhibitionSlug,
+  visitUrl,
+  className,
+}: EnterExhibitionButtonProps) => {
+  return (
+    <div
+      onClick={() => {
+        try {
+          sessionStorage.setItem(
+            'the-art-room:internal-nav',
+            JSON.stringify({
+              from: 'exhibition',
+              returnUrl: `/exhibitions/${artistSlug}/${exhibitionSlug}`,
+            }),
+          )
+        } catch {}
+      }}
+    >
+      <Button
+        variant="primary"
+        size="regularSquared"
+        label="Enter Virtual Exhibition"
+        href={visitUrl}
+        iconLeft={<ArrowRight size={16} strokeWidth={ICON_STROKE_WIDTH} />}
+        className={className}
+      />
+    </div>
+  )
+}

--- a/src/components/exhibitions/profile/index.tsx
+++ b/src/components/exhibitions/profile/index.tsx
@@ -1,12 +1,7 @@
-'use client'
-
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { ArrowRight } from 'lucide-react'
-import { ICON_STROKE_WIDTH } from '@/lib/iconConfig'
+
 import { ArtworkGrid } from '@/components/artwork/ArtworkGrid'
-import { Button } from '@/components/ui/Button'
 import { PageLayout } from '@/components/ui/PageLayout'
 import { RichText } from '@/components/ui/RichText'
 import { Share } from '@/components/ui/Share'
@@ -15,6 +10,7 @@ import { isRichTextEmpty } from '@/lib/textUtils'
 import { isSafeImageSrc } from '@/lib/imageSafety'
 import type { PublicExhibition } from '@/lib/queries/getPublicExhibitionByUrl'
 
+import { EnterExhibitionButton } from './EnterExhibitionButton'
 import styles from './ExhibitionProfile.module.scss'
 
 interface ExhibitionProfilePageProps {
@@ -23,14 +19,14 @@ interface ExhibitionProfilePageProps {
   exhibition: PublicExhibition
 }
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://theartroom.gallery'
+
 export const ExhibitionProfilePage = ({
   artistSlug,
   exhibitionSlug,
   exhibition,
 }: ExhibitionProfilePageProps) => {
-  const pathname = usePathname()
-
-  const shareUrl = typeof window !== 'undefined' ? `${window.location.origin}${pathname}` : ''
+  const shareUrl = `${SITE_URL}/exhibitions/${artistSlug}/${exhibitionSlug}`
   const visitUrl = `/exhibitions/${artistSlug}/${exhibitionSlug}/visit`
   const artistName = `${exhibition.user.name} ${exhibition.user.lastName}`
 
@@ -59,28 +55,12 @@ export const ExhibitionProfilePage = ({
             <Link href={`/artists/${exhibition.user.handler}`} className={styles.artist}>
               {artistName}
             </Link>
-            <div
-              onClick={() => {
-                try {
-                  sessionStorage.setItem(
-                    'the-art-room:internal-nav',
-                    JSON.stringify({
-                      from: 'exhibition',
-                      returnUrl: `/exhibitions/${artistSlug}/${exhibitionSlug}`,
-                    }),
-                  )
-                } catch {}
-              }}
-            >
-              <Button
-                variant="primary"
-                size="regularSquared"
-                label="Enter Virtual Exhibition"
-                href={visitUrl}
-                iconLeft={<ArrowRight size={16} strokeWidth={ICON_STROKE_WIDTH} />}
-                className={styles.button}
-              />
-            </div>
+            <EnterExhibitionButton
+              artistSlug={artistSlug}
+              exhibitionSlug={exhibitionSlug}
+              visitUrl={visitUrl}
+              className={styles.button}
+            />
             <Share
               title={`${exhibition.mainTitle} — ${artistName}`}
               url={shareUrl}


### PR DESCRIPTION
…ndle

CLS:
- Drop max-height: 600px on the ArtworkGrid image. With per-tile width/ height already passed to next/image, the cap created a mismatch between reserved slot and rendered slot for tall portraits, producing CLS on every grid render.
- Switch bodyFont (Lato) + headingFont (EB Garamond) to display: 'optional'. Removes font-swap CLS. Trade-off: slow-network first visits see the size-adjusted fallback for the whole pageview.

Server-component lift:
- exhibitions/profile becomes a server component. The sessionStorage- writing CTA is extracted into EnterExhibitionButton as a small client island; the rest (hero, dates, description, grid) ships as HTML and share URL is derived at SSR time from NEXT_PUBLIC_SITE_URL.
- artists/profile becomes a server component. The 'use client' on it wasn't actually using any client API.

Asset wiring:
- Preconnect to assets.theartroom.gallery from the root layout so the hero image's TLS handshake overlaps HTML parsing instead of blocking LCP.

Not landing here:
- Converting ArtworkGrid to a server component triggered a hydration mismatch involving next/link wrapping ProtectedImage (a client component) inside a server-rendered .map() under Next.js 16 / Turbopack. Reverted; needs a smaller repro before reopening.
- Wall fonts scoped to editor routes (touches the 2D wallview which is part of the exhibition-editing workflow; out of scope).