### PR TITLE
LG-113: add opt-in pnpm test:e2e:prod-build for production-runtime e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
@@ -19,6 +19,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:send-emails": "E2E_SEND_EMAILS=true playwright test",
+    "test:e2e:prod-build": "E2E_PROD_BUILD=true playwright test",
     "test:e2e:install": "playwright install chromium",
     "prepare": "husky"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,6 +70,22 @@ const emailSkipEnv: Record<string, string> = sendEmails
       SKIP_LOGIN_OTP: 'true',
     }
 
+// Opt-in: run the suite against a real production build (`next build &&
+// next start`) instead of the default `next dev`. Use sparingly — for
+// big refactors, `'use client'` ↔ server-component conversions, dep
+// upgrades, or anything that changes module loading. The dev server's
+// loader is more forgiving than Vercel's serverless runtime; this mode
+// catches the class of regression that 500'd prod on LG-112. Each run
+// adds ~30–60s for the build.
+//
+// Caveats when E2E_PROD_BUILD=true:
+//   - NODE_ENV becomes "production", so the SKIP_EMAILS / SKIP_LOGIN_*
+//     guards (which check `NODE_ENV !== 'production'`) are bypassed:
+//     two real login-code emails fire to the test creds on each run.
+//   - AUTH_TRUST_HOST=true is required to let NextAuth issue sessions
+//     on localhost in prod mode (UntrustedHost otherwise).
+const prodBuild = process.env.E2E_PROD_BUILD === 'true'
+
 export default defineConfig({
   testDir: './e2e',
   // globalSetup runs once before any spec. It logs in as admin and
@@ -108,10 +124,10 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'next dev -p 3001',
+    command: prodBuild ? 'next build && next start -p 3001' : 'next dev -p 3001',
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 120_000,
-    env: emailSkipEnv,
+    timeout: prodBuild ? 180_000 : 120_000,
+    env: prodBuild ? { ...emailSkipEnv, AUTH_TRUST_HOST: 'true' } : emailSkipEnv,
   },
 })


### PR DESCRIPTION
Default `pnpm test:e2e` continues to run against `next dev`, which is fast (~60s) and fine for day-to-day. The new `pnpm test:e2e:prod-build` opts into running the same suite against a real production build (`next build && next start -p 3001`) — the runtime Vercel actually serves.

Why this matters: LG-112 (May 2026) shipped a regression that passed the full e2e suite against `next dev` and 500'd every public profile page in production. The root cause was a CJS/ESM mismatch in a transitive dep that only manifests in the prod bundle's strict module loader. Dev mode bridged the mismatch invisibly. The new script gives us a way to run the suite under prod-parity conditions for:

- `'use client'` ↔ server-component conversions
- dep bumps that touch fragile chains (jsdom, dompurify, native bindings)
- changes to `next.config.mjs`, root layout, `instrumentation.*`
- big refactors before merging

Caveats when E2E_PROD_BUILD=true:
- NODE_ENV becomes "production", so the SKIP_LOGIN_EMAIL guard in send-login-code/route.ts (which checks `NODE_ENV !== 'production'`) is bypassed: two real login OTP emails fire to the test creds on each run. Acceptable for occasional manual use; a follow-up can add an E2E_TEST_MODE escape hatch in that route.
- AUTH_TRUST_HOST=true is injected via webServer.env so NextAuth issues sessions on localhost in prod mode.