### PR TITLE
fix(LG-119): replace Swiper hero carousel to stop resize flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
@@ -69,7 +69,6 @@
     "resend": "^6.9.3",
     "sharp": "^0.34.5",
     "stripe": "^22.0.1",
-    "swiper": "^12.1.2",
     "three": "^0.175.0",
     "three-stdlib": "^2.36.1",
     "utif": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,6 @@ importers:
       stripe:
         specifier: ^22.0.1
         version: 22.0.1(@types/node@24.3.0)
-      swiper:
-        specifier: ^12.1.2
-        version: 12.1.2
       three:
         specifier: ^0.175.0
         version: 0.175.0
@@ -5493,10 +5490,6 @@ packages:
 
   svix@1.84.1:
     resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
-
-  swiper@12.1.2:
-    resolution: {integrity: sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==}
-    engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -12181,8 +12174,6 @@ snapshots:
     dependencies:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
-
-  swiper@12.1.2: {}
 
   symbol-tree@3.2.4: {}
 

--- a/src/components/PrintWizard/PrintWizard.module.scss
+++ b/src/components/PrintWizard/PrintWizard.module.scss
@@ -101,6 +101,9 @@
     border-right: none;
     border-bottom: 1px solid var(--color-border-light);
     order: 2;
+    // Page scrolls on mobile (no internal panel scroll), so the
+    // desktop tooltip-clearance bottom padding becomes dead space.
+    padding-bottom: var(--space-6);
   }
 }
 
@@ -753,7 +756,8 @@
 
   @media (max-width: 900px) {
     border-left: none;
-    border-top: 1px solid var(--color-border-light);
+    // No border-top here — .stepsPanel's mobile border-bottom already
+    // draws the boundary; having both produces a doubled line.
     order: 3;
   }
 }

--- a/src/components/landing/FeaturedArtists/FeaturedArtists.module.scss
+++ b/src/components/landing/FeaturedArtists/FeaturedArtists.module.scss
@@ -46,6 +46,10 @@
   flex-direction: column;
 }
 
+.artistName {
+  line-height: 1;
+}
+
 .biography {
   font-size: var(--text-xs);
   color: var(--color-text-secondary);

--- a/src/components/landing/Slideshow/Slideshow.module.scss
+++ b/src/components/landing/Slideshow/Slideshow.module.scss
@@ -7,10 +7,6 @@
   overflow: hidden;
   margin-bottom: var(--space-6);
 
-  // Mobile: block all interaction (swipe / tap / pagination clicks /
-  // slide link). Carousel just auto-rotates. Swipe handlers on mobile
-  // were intercepting vertical scroll and getting "stuck" mid-slide.
-  // Autoplay is JS-driven so it keeps running.
   @media (max-width: 767px) {
     pointer-events: none;
   }
@@ -25,14 +21,8 @@
   }
 }
 
-.swiper {
-  width: 100%;
-  height: 100%;
-}
-
 .slide {
   display: block;
-  position: relative;
   width: 100%;
   height: 100%;
   text-decoration: none;
@@ -49,11 +39,8 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  will-change: transform;
-  backface-visibility: hidden;
+  object-fit: cover;
+  object-position: center;
 }
 
 .container {
@@ -85,9 +72,6 @@
 
 .meta {
   position: relative;
-  // color + border follow the parent .content's inline `color`, set
-  // per-slide from Slide.textColor (defaults to #ffffff). currentColor
-  // ties the underline border to the same value.
   color: inherit;
   text-transform: uppercase;
   letter-spacing: var(--space-1);
@@ -100,10 +84,7 @@
 .title {
   position: relative;
   color: inherit;
-  // Tighten vertical rhythm for titles that wrap to multiple lines.
-  // The default huge-size line-height left too much air between
-  // wrapped artist-name lines.
-  line-height: 1.05;
+  line-height: 1;
 }
 
 .subtitle {
@@ -112,13 +93,10 @@
   margin-top: var(--space-2);
 }
 
-.paginationContainer {
-  position: absolute;
-  bottom: var(--space-4);
+.dots {
   left: 0;
   right: 0;
-  z-index: 10;
-  width: 100%;
+  transform: none;
   max-width: var(--header-max-width);
   margin: 0 auto;
   padding: 0 var(--space-6);
@@ -127,22 +105,4 @@
     bottom: var(--space-6);
     padding: 0 var(--site-padding);
   }
-}
-
-.pagination {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.bullet {
-  width: var(--space-1);
-  height: var(--space-1);
-  background: var(--color-white);
-  border-radius: 50%;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.bulletActive {
-  background: var(--color-black);
 }

--- a/src/components/landing/Slideshow/Slideshow.tsx
+++ b/src/components/landing/Slideshow/Slideshow.tsx
@@ -1,11 +1,6 @@
-'use client'
-
-import { Swiper, SwiperSlide } from 'swiper/react'
-import { Autoplay, Pagination } from 'swiper/modules'
 import Link from 'next/link'
+import { Carousel } from '@/components/ui/Carousel'
 import { Text } from '@/components/ui/Typography'
-import 'swiper/css'
-import 'swiper/css/pagination'
 
 import styles from './Slideshow.module.scss'
 
@@ -26,56 +21,34 @@ type SlideshowProps = {
 export const Slideshow = ({ slides }: SlideshowProps) => {
   return (
     <div className={styles.slideshow}>
-      <Swiper
-        modules={[Autoplay, Pagination]}
-        spaceBetween={0}
-        slidesPerView={1}
-        loop
-        speed={800}
-        autoplay={{
-          delay: 5000,
-          disableOnInteraction: false,
-          pauseOnMouseEnter: true,
-        }}
-        pagination={{
-          clickable: true,
-          el: `.${styles.pagination}`,
-          bulletClass: styles.bullet,
-          bulletActiveClass: styles.bulletActive,
-        }}
-        className={styles.swiper}
-      >
-        {slides.map((slide) => (
-          <SwiperSlide key={slide.id}>
-            <Link href={slide.exhibitionUrl} className={styles.slide}>
-              <div
-                className={styles.background}
-                style={{ backgroundImage: `url(${slide.imageUrl})` }}
-              />
-              <div className={styles.container}>
-                <div className={styles.content} style={{ color: slide.textColor || '#ffffff' }}>
-                  {slide.meta && (
-                    <Text as="p" size="sm" className={styles.meta}>
-                      {slide.meta}
-                    </Text>
-                  )}
-                  <Text as="h2" size="huge" font="serif" className={styles.title}>
-                    {slide.title}
+      <Carousel
+        dotsClassName={styles.dots}
+        slides={slides.map((slide, index) => (
+          <Link key={slide.id} href={slide.exhibitionUrl} className={styles.slide}>
+            <img
+              src={slide.imageUrl}
+              alt=""
+              className={styles.background}
+              loading={index === 0 ? 'eager' : 'lazy'}
+            />
+            <div className={styles.container}>
+              <div className={styles.content} style={{ color: slide.textColor || '#ffffff' }}>
+                {slide.meta && (
+                  <Text as="p" size="sm" className={styles.meta}>
+                    {slide.meta}
                   </Text>
-                  <Text as="p" size="xl" font="serif" className={styles.subtitle}>
-                    {slide.subtitle}
-                  </Text>
-                </div>
+                )}
+                <Text as="h2" size="huge" font="serif" className={styles.title}>
+                  {slide.title}
+                </Text>
+                <Text as="p" size="xl" font="serif" className={styles.subtitle}>
+                  {slide.subtitle}
+                </Text>
               </div>
-            </Link>
-          </SwiperSlide>
+            </div>
+          </Link>
         ))}
-      </Swiper>
-      {slides.length > 1 && (
-        <div className={styles.paginationContainer}>
-          <div className={styles.pagination} />
-        </div>
-      )}
+      />
     </div>
   )
 }

--- a/src/components/ui/Carousel/Carousel.module.scss
+++ b/src/components/ui/Carousel/Carousel.module.scss
@@ -1,0 +1,41 @@
+.carousel {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  z-index: 1;
+  transition: opacity 800ms ease;
+}
+
+.slideActive {
+  opacity: 1;
+  z-index: 2;
+}
+
+.dots {
+  position: absolute;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.dot {
+  width: var(--space-1);
+  height: var(--space-1);
+  background: var(--color-white);
+  border-radius: 50%;
+  transition: background 0.2s ease;
+}
+
+.dotActive {
+  background: var(--color-black);
+}

--- a/src/components/ui/Carousel/Carousel.tsx
+++ b/src/components/ui/Carousel/Carousel.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import c from 'classnames'
+
+import styles from './Carousel.module.scss'
+
+type CarouselProps = {
+  slides: ReactNode[]
+  interval?: number
+  className?: string
+  dotsClassName?: string
+}
+
+const Carousel = ({ slides, interval = 5000, className, dotsClassName }: CarouselProps) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  useEffect(() => {
+    if (slides.length <= 1) return
+    const id = window.setInterval(() => {
+      setActiveIndex((i) => (i + 1) % slides.length)
+    }, interval)
+    return () => window.clearInterval(id)
+  }, [slides.length, interval])
+
+  return (
+    <div className={c(styles.carousel, className)}>
+      {slides.map((slide, index) => (
+        <div
+          key={index}
+          className={c(styles.slide, index === activeIndex && styles.slideActive)}
+        >
+          {slide}
+        </div>
+      ))}
+      {slides.length > 1 && (
+        <div className={c(styles.dots, dotsClassName)}>
+          {slides.map((_, index) => (
+            <span
+              key={index}
+              className={c(styles.dot, index === activeIndex && styles.dotActive)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Carousel

--- a/src/components/ui/Carousel/index.ts
+++ b/src/components/ui/Carousel/index.ts
@@ -1,0 +1,1 @@
+export { default as Carousel } from './Carousel'

--- a/src/components/ui/NavigationProgressBar/NavigationProgressBar.tsx
+++ b/src/components/ui/NavigationProgressBar/NavigationProgressBar.tsx
@@ -83,7 +83,7 @@ export function NavigationProgressBar() {
     }
 
     // Capture phase so we still see the click if a downstream handler
-    // (e.g. Swiper's slide-click logic) calls stopPropagation in bubble.
+    // calls stopPropagation in bubble.
     document.addEventListener('click', onClick, { capture: true })
     return () => document.removeEventListener('click', onClick, { capture: true })
   }, [])


### PR DESCRIPTION
- New Carousel UI primitive: auto-fade, read-only dot indicators, no resize observers or transform math (flicker becomes structurally impossible)
- Slideshow refactored to consume Carousel
- swiper dependency removed
- Featured Artists: tighten line-height on wrapping artist names
- Print wizard mobile: reduce dead bottom padding under steps panel, remove duplicate border between steps and summary