### PR TITLE
hotfix: CMS pages back to static + carousel height, to fix staging

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next'
 import { AboutPage } from '@/components/about'
 import { getStaticPageContent } from '@/lib/queries/getStaticPageContent'
 
-// Render per request and read straight from the DB so admin edits appear
-// immediately. Verified on staging: server-side <RichText> (isomorphic-
-// dompurify) renders at runtime without the AR-112 500 — the artwork and
-// exhibition pages already do the same in prod. No cache, no revalidation.
-export const dynamic = 'force-dynamic'
+// ISR so admin edits show without a redeploy. `revalidatePath` (in the pages
+// API) only refreshes a route that opts into ISR via `revalidate`; a fully
+// static page is an immutable asset Vercel won't purge on demand. 1h is the
+// background fallback. NOT force-dynamic (runtime render 500s in prod — AR-112).
+export const revalidate = 3600
 
 export const metadata: Metadata = {
   title: { absolute: 'About The Art Room' },

--- a/src/app/accessibility-policy/page.tsx
+++ b/src/app/accessibility-policy/page.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next'
 import { AccessibilityPage } from '@/components/accessibility'
 import { getStaticPageContent } from '@/lib/queries/getStaticPageContent'
 
-// Render per request and read straight from the DB so admin edits appear
-// immediately. Verified on staging: server-side <RichText> (isomorphic-
-// dompurify) renders at runtime without the AR-112 500 — the artwork and
-// exhibition pages already do the same in prod. No cache, no revalidation.
-export const dynamic = 'force-dynamic'
+// ISR so admin edits show without a redeploy. `revalidatePath` (in the pages
+// API) only refreshes a route that opts into ISR via `revalidate`; a fully
+// static page is an immutable asset Vercel won't purge on demand. 1h is the
+// background fallback. NOT force-dynamic (runtime render 500s in prod — AR-112).
+export const revalidate = 3600
 
 export const metadata: Metadata = {
   title: { absolute: 'The Art Room Accessibility Policy' },

--- a/src/app/prints/page.tsx
+++ b/src/app/prints/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache'
 import type { Metadata } from 'next'
 
 import { PrintsPage } from '@/components/prints'
@@ -9,53 +10,57 @@ export const metadata: Metadata = {
     'Order fine-art prints of selected works from The Art Room artists, produced on museum-grade paper.',
 }
 
-// Render per request and read straight from the DB so print toggles, prices
-// and CMS copy edits appear immediately. Renders <RichText> server-side, same
-// as the now-dynamic content pages — verified safe on staging. No cache.
-export const dynamic = 'force-dynamic'
-
-const getPrintsPage = async () => {
-  const [artworksRaw, page] = await Promise.all([
-    prisma.artwork.findMany({
-      where: {
-        printEnabled: true,
-        printPriceCents: { not: null },
-        user: { published: true },
-      },
-      select: {
-        id: true,
-        slug: true,
-        title: true,
-        name: true,
-        author: true,
-        year: true,
-        imageUrl: true,
-        originalWidth: true,
-        originalHeight: true,
-        createdAt: true,
-        user: {
-          select: {
-            id: true,
-            name: true,
-            lastName: true,
-            handler: true,
+// Tags match existing API tags so write-path revalidations cover this
+// surface too: 'page-prints' (CMS edit), 'artworks' (artwork edit).
+const getCachedPrintsPage = unstable_cache(
+  async () => {
+    const [artworksRaw, page] = await Promise.all([
+      prisma.artwork.findMany({
+        where: {
+          printEnabled: true,
+          printPriceCents: { not: null },
+          user: { published: true },
+        },
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          name: true,
+          author: true,
+          year: true,
+          imageUrl: true,
+          originalWidth: true,
+          originalHeight: true,
+          createdAt: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              lastName: true,
+              handler: true,
+            },
           },
         },
-      },
-      orderBy: { createdAt: 'desc' },
-    }),
-    prisma.pageContent.findUnique({ where: { slug: 'prints' } }),
-  ])
-  // PrintsPage expects createdAt as an ISO string, so normalize here.
-  const artworks = artworksRaw.map((a) => ({
-    ...a,
-    createdAt: a.createdAt.toISOString(),
-  }))
-  return { artworks, page }
-}
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.pageContent.findUnique({ where: { slug: 'prints' } }),
+    ])
+    // Convert Date → ISO string before the cache stores the payload.
+    // unstable_cache serializes on store; reading a cached entry gives
+    // back a string, so calling .toISOString() outside this function
+    // crashes on cache hits.
+    const artworks = artworksRaw.map((a) => ({
+      ...a,
+      createdAt: a.createdAt.toISOString(),
+    }))
+    return { artworks, page }
+  },
+  ['prints-public-page'],
+  { tags: ['page-prints', 'artworks'], revalidate: 3600 },
+)
 
 const Prints = async () => {
-  const { artworks, page: pageRaw } = await getPrintsPage()
+  const { artworks, page: pageRaw } = await getCachedPrintsPage()
 
   const pageContent = pageRaw
     ? {

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next'
 import { PrivacyPage } from '@/components/privacy'
 import { getStaticPageContent } from '@/lib/queries/getStaticPageContent'
 
-// Render per request and read straight from the DB so admin edits appear
-// immediately. Verified on staging: server-side <RichText> (isomorphic-
-// dompurify) renders at runtime without the AR-112 500 — the artwork and
-// exhibition pages already do the same in prod. No cache, no revalidation.
-export const dynamic = 'force-dynamic'
+// ISR so admin edits show without a redeploy. `revalidatePath` (in the pages
+// API) only refreshes a route that opts into ISR via `revalidate`; a fully
+// static page is an immutable asset Vercel won't purge on demand. 1h is the
+// background fallback. NOT force-dynamic (runtime render 500s in prod — AR-112).
+export const revalidate = 3600
 
 export const metadata: Metadata = {
   title: { absolute: 'The Art Room Privacy Policy' },

--- a/src/app/terms-and-conditions/page.tsx
+++ b/src/app/terms-and-conditions/page.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next'
 import { TermsPage } from '@/components/terms'
 import { getStaticPageContent } from '@/lib/queries/getStaticPageContent'
 
-// Render per request and read straight from the DB so admin edits appear
-// immediately. Verified on staging: server-side <RichText> (isomorphic-
-// dompurify) renders at runtime without the AR-112 500 — the artwork and
-// exhibition pages already do the same in prod. No cache, no revalidation.
-export const dynamic = 'force-dynamic'
+// ISR so admin edits show without a redeploy. `revalidatePath` (in the pages
+// API) only refreshes a route that opts into ISR via `revalidate`; a fully
+// static page is an immutable asset Vercel won't purge on demand. 1h is the
+// background fallback. NOT force-dynamic (runtime render 500s in prod — AR-112).
+export const revalidate = 3600
 
 export const metadata: Metadata = {
   title: { absolute: 'The Art Room Terms and Conditions' },

--- a/src/app/terms-of-sale/page.tsx
+++ b/src/app/terms-of-sale/page.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next'
 import { TermsOfSalePage } from '@/components/terms-of-sale'
 import { getStaticPageContent } from '@/lib/queries/getStaticPageContent'
 
-// Render per request and read straight from the DB so admin edits appear
-// immediately. Verified on staging: server-side <RichText> (isomorphic-
-// dompurify) renders at runtime without the AR-112 500 — the artwork and
-// exhibition pages already do the same in prod. No cache, no revalidation.
-export const dynamic = 'force-dynamic'
+// ISR so admin edits show without a redeploy. `revalidatePath` (in the pages
+// API) only refreshes a route that opts into ISR via `revalidate`; a fully
+// static page is an immutable asset Vercel won't purge on demand. 1h is the
+// background fallback. NOT force-dynamic (runtime render 500s in prod — AR-112).
+export const revalidate = 3600
 
 export const metadata: Metadata = {
   title: { absolute: 'Online Terms of Sale — The Art Room' },

--- a/src/components/landing/Slideshow/Slideshow.module.scss
+++ b/src/components/landing/Slideshow/Slideshow.module.scss
@@ -3,7 +3,7 @@
 .slideshow {
   position: relative;
   width: 100%;
-  height: 680px;
+  height: 520px;
   overflow: hidden;
   margin-bottom: var(--space-6);
 


### PR DESCRIPTION
develop (staging) had two problems prod (main) already had right:

- CMS content pages (about, terms-and-conditions, terms-of-sale, privacy-policy, accessibility-policy, prints) were force-dynamic, which 500s at runtime on Vercel — they render <RichText> server-side via isomorphic-dompurify (jsdom), which fails on the serverless runtime. Reverted to static ISR, matching main.
- Slideshow height was 680px (too tall, esp. mobile); set to 520px, matching main's carousel fix (d68b767).

Both files taken verbatim from origin/main. develop already has the AR-122 features, so nothing else changes.