### PR TITLE
Fix/AR-125: Fix Exhibition Images

### DIFF
--- a/e2e/exhibition-images.spec.ts
+++ b/e2e/exhibition-images.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+import { routes } from './fixtures'
+
+/**
+ * Every image on the public exhibition page must actually PAINT — not just
+ * return 200 HTML.
+ *
+ * AR-125: exhibition images broke on first load (a failed `/_next/image` cold
+ * transform on Vercel) yet the page was a clean 200 and the profile-render
+ * smoke test still passed — the broken image was invisible to e2e *and* to
+ * Sentry (a broken <img> doesn't throw). Asserting `naturalWidth > 0` is what
+ * catches this class of bug deterministically.
+ *
+ * Scope: the WebGL-free exhibition PROFILE page only. The 3D `/visit` route and
+ * the artwork-detail viewer mount R3F/WebGL and are deliberately excluded
+ * (see memory: no WebGL e2e).
+ */
+test(`all images paint (naturalWidth > 0): exhibition profile`, async ({ page }) => {
+  const path = routes.exhibition()
+  const response = await page.goto(path)
+  expect(response?.status() ?? 0, `${path} returned a non-200`).toBe(200)
+
+  // Trigger lazy-loaded (below-the-fold) grid images before asserting.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        let y = 0
+        const step = () => {
+          window.scrollTo(0, y)
+          y += window.innerHeight
+          if (y < document.body.scrollHeight) {
+            requestAnimationFrame(step)
+          } else {
+            window.scrollTo(0, 0)
+            resolve()
+          }
+        }
+        step()
+      }),
+  )
+
+  // Poll until every real <img> has decoded, then assert none failed. Skips
+  // inline data:/blob: placeholders (e.g. blur placeholders), which have no
+  // network fetch to fail.
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() =>
+          Array.from(document.querySelectorAll('img'))
+            .filter((img) => {
+              const src = img.currentSrc || img.src
+              return Boolean(src) && !src.startsWith('data:') && !src.startsWith('blob:')
+            })
+            .filter((img) => !img.complete || img.naturalWidth === 0)
+            .map((img) => img.currentSrc || img.src),
+        ),
+      {
+        message: `${path}: these images failed to paint (naturalWidth 0)`,
+        timeout: 15_000,
+      },
+    )
+    .toEqual([])
+})

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,6 +3,12 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+  // Tag every event with the build the client booted, so we can spot errors
+  // coming from users stuck on a stale/cached version (compared to /api/version).
+  initialScope: {
+    tags: { client_build: process.env.NEXT_PUBLIC_BUILD_ID || 'dev' },
+  },
+
   // Performance monitoring
   tracesSampleRate: 1.0,
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,13 @@ import { withSentryConfig } from '@sentry/nextjs'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   serverExternalPackages: ['@prisma/client', '@prisma/client-runtime-utils'],
+  // Stamp the deployed commit SHA into the client bundle so a running tab knows
+  // which build it booted. Compared against the server's live SHA (/api/version)
+  // to detect users stuck on a stale/cached version. Vercel sets
+  // VERCEL_GIT_COMMIT_SHA at build; 'dev' locally.
+  env: {
+    NEXT_PUBLIC_BUILD_ID: process.env.VERCEL_GIT_COMMIT_SHA || 'dev',
+  },
   images: {
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
@@ -92,6 +99,11 @@ const nextConfig = {
 }
 
 export default withSentryConfig(nextConfig, {
+  // Proxy client-side Sentry events through our own domain instead of
+  // *.ingest.sentry.io, which ad blockers / privacy extensions / Brave block.
+  // Without this, a large share of browser errors silently never arrive.
+  tunnelRoute: '/monitoring',
+
   // Upload source maps for readable stack traces in Sentry
   sourcemaps: {
     deleteSourcemapsAfterUpload: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,6 +3,11 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+  // Tag events with the running deployment's build (edge runtime).
+  initialScope: {
+    tags: { client_build: process.env.NEXT_PUBLIC_BUILD_ID || 'dev' },
+  },
+
   // Performance monitoring
   tracesSampleRate: 1.0,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,6 +3,11 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+  // Tag events with the running deployment's build (server side).
+  initialScope: {
+    tags: { client_build: process.env.NEXT_PUBLIC_BUILD_ID || 'dev' },
+  },
+
   // Performance monitoring
   tracesSampleRate: 1.0,
 

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Returns the build of the deployment currently serving requests. The client
+ * (VersionGuard) compares this against the build its tab booted to detect users
+ * stuck on a stale/cached version. Must never be cached.
+ */
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  const build = process.env.VERCEL_GIT_COMMIT_SHA || process.env.NEXT_PUBLIC_BUILD_ID || 'dev'
+
+  return NextResponse.json({ build }, { headers: { 'Cache-Control': 'no-store' } })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { AuthProvider } from '@/components/providers/AuthProvider'
 import { ImageProtection } from '@/components/providers/ImageProtection'
 import { CookieBanner } from '@/components/ui/CookieBanner'
 import { NavigationProgressBar } from '@/components/ui/NavigationProgressBar'
+import { VersionGuard } from '@/components/observability/VersionGuard'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import '@/styles/globals.scss'
@@ -100,6 +101,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <SpeedInsights />
         <CookieBanner />
         <GoogleAnalytics />
+        <VersionGuard />
       </body>
     </html>
   )

--- a/src/components/PrintWizard/StepsPanel.tsx
+++ b/src/components/PrintWizard/StepsPanel.tsx
@@ -281,7 +281,9 @@ const PrintAndPaperSection = ({
         label: option.label,
         tooltip: optionTooltip(option),
         tooltipImage: option.tooltipImageUrl ? (
-          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} />
+          // unoptimized: catalog image; skip the Vercel optimizer whose cold
+          // re-encode broke images on first load (AR-125).
+          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} unoptimized />
         ) : undefined,
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -301,7 +303,8 @@ const PrintAndPaperSection = ({
           label: option.label,
           tooltip: optionTooltip(option, isRecommended),
           tooltipImage: option.tooltipImageUrl ? (
-            <Image src={option.tooltipImageUrl} alt="" width={220} height={220} />
+            // unoptimized: catalog image; skip the Vercel optimizer (AR-125).
+            <Image src={option.tooltipImageUrl} alt="" width={220} height={220} unoptimized />
           ) : undefined,
           badge: isRecommended ? (
             <Icon name="check-circle" size={16} aria-label="Recommended by the artist" />
@@ -556,7 +559,9 @@ const EnumDropdown = ({
         label: option.label,
         tooltip: optionTooltip(option),
         tooltipImage: option.tooltipImageUrl ? (
-          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} />
+          // unoptimized: catalog image; skip the Vercel optimizer whose cold
+          // re-encode broke images on first load (AR-125).
+          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} unoptimized />
         ) : undefined,
       })),
     [filtered],
@@ -741,7 +746,9 @@ const EnumDimensionSection = ({
         label: option.label,
         tooltip: optionTooltip(option),
         tooltipImage: option.tooltipImageUrl ? (
-          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} />
+          // unoptimized: catalog image; skip the Vercel optimizer whose cold
+          // re-encode broke images on first load (AR-125).
+          <Image src={option.tooltipImageUrl} alt="" width={220} height={220} unoptimized />
         ) : undefined,
       })),
     [filtered],
@@ -1086,7 +1093,14 @@ function optionTooltip(option: Option, recommended?: boolean): ReactNode {
     <>
       {option.tooltipHeaderImageUrl && (
         <div className={styles.tooltipHeaderImage}>
-          <Image src={option.tooltipHeaderImageUrl} alt="" width={640} height={360} sizes="320px" />
+          <Image
+            src={option.tooltipHeaderImageUrl}
+            alt=""
+            width={640}
+            height={360}
+            sizes="320px"
+            unoptimized
+          />
         </div>
       )}
       <p>

--- a/src/components/analytics/GoogleAnalytics.tsx
+++ b/src/components/analytics/GoogleAnalytics.tsx
@@ -14,6 +14,10 @@ import Script from 'next/script'
  *   who already accepted are measured immediately.
  */
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+// Deployed build the client booted. Sent as a GA4 param so any metric can be
+// segmented by app version (register `app_version` as a custom dimension in GA4
+// to report on it). Lets us see if traffic is coming from a stale/cached build.
+const BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID || 'dev'
 
 export const GoogleAnalytics = () => {
   if (!GA_MEASUREMENT_ID) return null
@@ -41,7 +45,7 @@ export const GoogleAnalytics = () => {
                 gtag('consent', 'update', { analytics_storage: 'granted' });
               }
             } catch (e) {}
-            gtag('config', '${GA_MEASUREMENT_ID}');
+            gtag('config', '${GA_MEASUREMENT_ID}', { app_version: '${BUILD_ID}' });
           `,
         }}
       />

--- a/src/components/artwork/detail/ArtworkDetailBody.tsx
+++ b/src/components/artwork/detail/ArtworkDetailBody.tsx
@@ -10,6 +10,7 @@ import { InquireSidebar } from '@/components/ui/InquireSidebar'
 import { Share } from '@/components/ui/Share'
 import { setPrintReturnUrl } from '@/components/checkout/printReturnUrl'
 import { isRichTextEmpty } from '@/lib/textUtils'
+import { reportImageError } from '@/lib/observability/reportImageError'
 
 import styles from './ArtworkDetail.module.scss'
 
@@ -138,6 +139,12 @@ export const ArtworkDetailBody = ({ artwork, artist }: ArtworkDetailBodyProps) =
             className={styles.image}
             crossOrigin="anonymous"
             decoding="async"
+            onError={() =>
+              reportImageError(artwork.imageUrl, {
+                surface: 'artwork-detail',
+                alt: displayTitle || undefined,
+              })
+            }
           />
         )}
       </div>

--- a/src/components/checkout/OrderSummary/index.tsx
+++ b/src/components/checkout/OrderSummary/index.tsx
@@ -75,6 +75,9 @@ export const OrderSummary = ({
             alt={artwork.title}
             width={72}
             height={72}
+            // Skip the Vercel optimizer (already-optimized R2/CDN .webp); cold
+            // re-encodes broke images on first load (AR-125).
+            unoptimized
             className={`${styles.summaryThumb}${thumbRotated ? ` ${styles.summaryThumbRotated}` : ''}`}
           />
         )}

--- a/src/components/checkout/PrintConfirmation/index.tsx
+++ b/src/components/checkout/PrintConfirmation/index.tsx
@@ -73,6 +73,9 @@ export const PrintConfirmation = ({ artwork, paymentIntentId, status }: PrintCon
               alt={artwork.title}
               width={120}
               height={120}
+              // Skip the Vercel optimizer (already-optimized R2/CDN .webp); cold
+              // re-encodes broke images on first load (AR-125).
+              unoptimized
               className={styles.thumb}
             />
           )}

--- a/src/components/dashboard/artworks/index.tsx
+++ b/src/components/dashboard/artworks/index.tsx
@@ -183,6 +183,9 @@ function ArtworkCard({
             alt={artwork.title || 'Artwork'}
             width={60}
             height={60}
+            // Skip the Vercel optimizer (already-optimized R2/CDN .webp); cold
+            // re-encodes broke images on first load (AR-125).
+            unoptimized
             className={styles.thumbnail}
           />
         ) : artwork.artworkType === 'video' && artwork.videoUrl ? (

--- a/src/components/exhibitions/index.tsx
+++ b/src/components/exhibitions/index.tsx
@@ -47,6 +47,9 @@ const ExhibitionCard = ({
             src={exhibition.featuredImageUrl}
             alt={exhibition.mainTitle}
             fill
+            // Skip the Vercel optimizer: source is already-optimized .webp on an
+            // immutable R2/CDN; cold re-encodes broke images on first load (AR-125).
+            unoptimized
             sizes="(max-width: 768px) 100vw, 55vw"
             className={styles.image}
             priority={priority}

--- a/src/components/exhibitions/profile/index.tsx
+++ b/src/components/exhibitions/profile/index.tsx
@@ -77,6 +77,11 @@ export const ExhibitionProfilePage = ({
                 alt={exhibition.mainTitle}
                 fill
                 priority
+                // Skip the Vercel /_next/image optimizer: the source is an
+                // already-optimized .webp on an immutable R2/CDN. Re-encoding it
+                // on a cold transform is what made images break on first load
+                // and only show after a refresh (AR-125).
+                unoptimized
                 sizes="(max-width: 768px) 100vw, 66vw"
                 className={styles.heroImage}
               />

--- a/src/components/landing/Slideshow/Slideshow.tsx
+++ b/src/components/landing/Slideshow/Slideshow.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import c from 'classnames'
 import { Text } from '@/components/ui/Typography'
+import { reportImageError } from '@/lib/observability/reportImageError'
 
 import styles from './Slideshow.module.scss'
 
@@ -46,6 +47,7 @@ export const Slideshow = ({ slides, interval = 5000 }: SlideshowProps) => {
             alt=""
             className={styles.background}
             loading={index === 0 ? 'eager' : 'lazy'}
+            onError={() => reportImageError(slide.imageUrl, { surface: 'home-slideshow' })}
           />
           <div className={styles.container}>
             <div className={styles.content} style={{ color: slide.textColor || '#ffffff' }}>

--- a/src/components/observability/VersionGuard.tsx
+++ b/src/components/observability/VersionGuard.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect } from 'react'
+import * as Sentry from '@sentry/nextjs'
+
+/**
+ * Detects when a tab is running a stale/cached build (old JS/HTML) after a newer
+ * deploy, and reports it to Sentry so we can SEE how many users are on outdated
+ * versions — a failure mode that's otherwise completely invisible (it doesn't
+ * throw; it just causes weird "works on refresh" behaviour). Launch hardening,
+ * see project_observability_instrumentation_map.
+ *
+ * It compares the build the tab booted (`NEXT_PUBLIC_BUILD_ID`, inlined at build
+ * time) against the server's live build (`/api/version`), on an interval and
+ * whenever the tab regains focus. Reports at most once per tab.
+ *
+ * Knowing != preventing: the actual safeguard against version skew is Vercel
+ * Skew Protection (a dashboard toggle). This is the visibility layer. A future
+ * enhancement can surface a "refresh for the latest version" prompt here.
+ */
+const BOOTED_BUILD = process.env.NEXT_PUBLIC_BUILD_ID || 'dev'
+const CHECK_INTERVAL_MS = 5 * 60 * 1000
+
+export const VersionGuard = () => {
+  useEffect(() => {
+    // No real build to compare against locally — skip entirely.
+    if (BOOTED_BUILD === 'dev') return
+
+    let reported = false
+
+    const check = async () => {
+      if (reported || document.visibilityState !== 'visible') return
+      try {
+        const res = await fetch('/api/version', { cache: 'no-store' })
+        if (!res.ok) return
+        const { build } = (await res.json()) as { build?: string }
+        if (!build || build === 'dev' || build === BOOTED_BUILD) return
+
+        reported = true
+        Sentry.withScope((scope) => {
+          scope.setLevel('warning')
+          scope.setTag('flow', 'version-skew')
+          scope.setFingerprint(['stale-client'])
+          scope.setExtra('bootedBuild', BOOTED_BUILD)
+          scope.setExtra('serverBuild', build)
+          Sentry.captureMessage('Stale client: tab is running an outdated build', 'warning')
+        })
+      } catch {
+        // Network blip — ignore and try again next tick.
+      }
+    }
+
+    const id = window.setInterval(check, CHECK_INTERVAL_MS)
+    const onVisible = () => check()
+    document.addEventListener('visibilitychange', onVisible)
+    // First check shortly after mount, once the page has settled.
+    const t = window.setTimeout(check, 10_000)
+
+    return () => {
+      window.clearInterval(id)
+      window.clearTimeout(t)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/prints/PrintsBanner.tsx
+++ b/src/components/prints/PrintsBanner.tsx
@@ -14,7 +14,17 @@ export const PrintsBanner = ({ imageUrl, alt }: Props) => {
 
   return (
     <div className={styles.banner}>
-      <Image src={imageUrl} alt={alt} fill priority sizes="100vw" className={styles.bannerImage} />
+      {/* unoptimized: serve the already-optimized R2/CDN .webp directly; the
+          Vercel optimizer's cold re-encode broke images on first load (AR-125). */}
+      <Image
+        src={imageUrl}
+        alt={alt}
+        fill
+        priority
+        unoptimized
+        sizes="100vw"
+        className={styles.bannerImage}
+      />
     </div>
   )
 }

--- a/src/components/ui/ImageLightbox/ImageLightbox.tsx
+++ b/src/components/ui/ImageLightbox/ImageLightbox.tsx
@@ -4,6 +4,7 @@ import { useEffect, useCallback } from 'react'
 
 import { Button } from '@/components/ui/Button'
 import { Text } from '@/components/ui/Typography'
+import { reportImageError } from '@/lib/observability/reportImageError'
 
 import styles from './ImageLightbox.module.scss'
 
@@ -60,6 +61,7 @@ export const ImageLightbox = ({ imageUrl, alt, caption, onClose }: ImageLightbox
         onContextMenu={(e) => e.preventDefault()}
         onDragStart={(e) => e.preventDefault()}
         draggable={false}
+        onError={() => reportImageError(imageUrl, { surface: 'lightbox', alt })}
         style={{ userSelect: 'none', WebkitTouchCallout: 'none' }}
       />
       {caption && (

--- a/src/components/ui/ImageUploader/ImageUploader.tsx
+++ b/src/components/ui/ImageUploader/ImageUploader.tsx
@@ -392,7 +392,10 @@ export const ImageUploader = ({
       {imageUrl ? (
         // Image preview state
         <div className={styles.preview} style={boxStyle}>
-          <Image src={imageUrl} alt="Uploaded image" fill style={{ objectFit }} />
+          {/* unoptimized: src is a local blob: preview or an already-optimized
+              R2/CDN .webp — no value in the Vercel optimizer, and its cold
+              re-encode broke remote previews on first load (AR-125). */}
+          <Image src={imageUrl} alt="Uploaded image" fill unoptimized style={{ objectFit }} />
           {onRemove && (
             <Button
               variant="ghost"

--- a/src/components/ui/ProtectedImage/ProtectedImage.tsx
+++ b/src/components/ui/ProtectedImage/ProtectedImage.tsx
@@ -3,6 +3,7 @@
 import Image, { type ImageProps } from 'next/image'
 
 import { isSafeImageSrc } from '@/lib/imageSafety'
+import { reportImageError } from '@/lib/observability/reportImageError'
 
 import styles from './ProtectedImage.module.scss'
 
@@ -22,6 +23,12 @@ export const ProtectedImage = ({
   wrapperClassName,
   fill,
   className,
+  // Default to skipping the Vercel /_next/image optimizer. Our sources are
+  // already-optimized .webp on an immutable R2/CDN; re-fetching + re-encoding
+  // them on a cold transform is what caused images to break on first load and
+  // only appear after a refresh (AR-125). Callers can still pass unoptimized={false}.
+  unoptimized = true,
+  onError,
   ...props
 }: ProtectedImageProps) => {
   const wrapperStyle = fill ? styles.fill : styles.wrapper
@@ -42,7 +49,21 @@ export const ProtectedImage = ({
       onContextMenu={(e) => e.preventDefault()}
       onDragStart={(e) => e.preventDefault()}
     >
-      <Image {...props} fill={fill} className={className} draggable={false} />
+      <Image
+        {...props}
+        fill={fill}
+        unoptimized={unoptimized}
+        className={className}
+        draggable={false}
+        onError={(e) => {
+          // Broken images don't throw — report so we see them in Sentry (AR-125).
+          reportImageError(props.src as string, {
+            surface: 'protected-image',
+            alt: typeof props.alt === 'string' ? props.alt : undefined,
+          })
+          onError?.(e)
+        }}
+      />
     </div>
   )
 }

--- a/src/lib/observability/captureError.ts
+++ b/src/lib/observability/captureError.ts
@@ -10,6 +10,8 @@ type Flow =
   | 'upload' // File uploads (artwork images, signatures)
   | 'stripe' // Stripe client calls (paymentIntents.*, transfers.*, refunds.*)
   | 'cron' // Scheduled jobs (reconciliation, etc.)
+  | 'content' // Public content reads (exhibition/artwork queries for display)
+  | 'image' // Image load failures on display surfaces (client-side)
 
 export type CaptureContext = {
   /** Broad business domain — groups related errors in Sentry filters. */

--- a/src/lib/observability/reportImageError.ts
+++ b/src/lib/observability/reportImageError.ts
@@ -1,0 +1,48 @@
+import * as Sentry from '@sentry/nextjs'
+
+/**
+ * Reports a failed image load to Sentry.
+ *
+ * Broken images don't throw — a failed `<img>` / next-image load fires the
+ * `onError` handler and the browser shows a broken icon, but nothing reaches
+ * Sentry. That's exactly how AR-125 (exhibition images broken on first load)
+ * produced a totally clean dashboard. Call this from image `onError` handlers
+ * so we find out the moment real users hit a missing/failed image.
+ *
+ * Deduped per URL for the tab's lifetime: a whole failing grid — or one image
+ * that re-errors on every re-render — collapses to a single Sentry event
+ * instead of a flood. The fingerprint groups all hits of the same URL (across
+ * users) into one issue.
+ */
+const reported = new Set<string>()
+
+type ImageErrorContext = {
+  /** Where it failed, e.g. 'exhibition-grid', 'artwork-detail', 'lightbox'. */
+  surface?: string
+  /** Alt text — helps identify which artwork in the Sentry event. */
+  alt?: string
+}
+
+export function reportImageError(
+  src: string | null | undefined,
+  context: ImageErrorContext = {},
+): void {
+  if (!src) return
+  if (reported.has(src)) return
+  reported.add(src)
+
+  try {
+    Sentry.withScope((scope) => {
+      scope.setLevel('warning')
+      scope.setTag('flow', 'image')
+      if (context.surface) scope.setTag('surface', context.surface)
+      // One Sentry issue per failing URL, regardless of how many users hit it.
+      scope.setFingerprint(['image-load-failed', src])
+      scope.setExtra('src', src)
+      if (context.alt) scope.setExtra('alt', context.alt)
+      Sentry.captureMessage(`Image failed to load: ${src}`, 'warning')
+    })
+  } catch {
+    // Observability must never break rendering.
+  }
+}

--- a/src/lib/queries/getPublicExhibitionByUrl.ts
+++ b/src/lib/queries/getPublicExhibitionByUrl.ts
@@ -1,4 +1,5 @@
 import prisma from '@/lib/prisma'
+import { captureError } from '@/lib/observability/captureError'
 
 // No data cache: read straight from the DB so library reordering and artwork
 // metadata edits propagate to the public exhibition page immediately. The
@@ -89,6 +90,25 @@ export type PublicExhibition = {
  * they're only consumed by the /visit route.
  */
 export async function getPublicExhibitionByUrl(url: string): Promise<PublicExhibition | null> {
+  // Report DB/read failures with flow context — they'd otherwise bubble to the
+  // Next error boundary (a 500 page) with no operator signal. Re-throw so the
+  // route's existing notFound/error handling is unchanged. (Observability
+  // hardening for launch — see project_observability_instrumentation_map.)
+  try {
+    return await loadPublicExhibition(url)
+  } catch (error) {
+    captureError(error, {
+      flow: 'content',
+      stage: 'get-public-exhibition',
+      level: 'error',
+      fingerprint: ['content:get-public-exhibition-failed'],
+      extra: { url },
+    })
+    throw error
+  }
+}
+
+async function loadPublicExhibition(url: string): Promise<PublicExhibition | null> {
   const exhibition = await getExhibition(url)
   if (!exhibition || !exhibition.published) return null
 


### PR DESCRIPTION
…hardening

## Image fix (root cause)
Exhibition/display images broke on first load and only appeared after a refresh. Cause: already-optimized .webp on an immutable R2/CDN were being re-fetched and re-encoded by the Vercel /_next/image optimizer; cold transforms under concurrent load intermittently fail. Serve them directly.

- ProtectedImage now defaults to `unoptimized` (covers grid, cards, avatars, inquire sidebar — 8+ surfaces); callers can override.
- Added `unoptimized` to the remaining direct next/image usages of remote R2 images: exhibition hero + cards, PrintsBanner, order summary/confirmation thumbs, dashboard artwork thumb, uploader preview, print-wizard tooltips.

## Observability (A) — make silent failures visible
- New reportImageError helper (Sentry captureMessage, deduped per URL) wired into ProtectedImage + raw <img> surfaces (artwork detail, lightbox, home slideshow). Broken images don't throw, so they were invisible before.
- getPublicExhibitionByUrl wraps its DB reads in captureError (new `content` flow) and re-throws — failures now report with context, behaviour unchanged.
- Sentry tunnelRoute '/monitoring' so client errors aren't ad-blocked.

## Version-skew visibility
- Stamp NEXT_PUBLIC_BUILD_ID (Vercel commit SHA) into the client bundle.
- Tag Sentry events with client_build; send GA4 app_version param.
- /api/version returns the live server build; VersionGuard compares it to the booted build and reports stale clients to Sentry.

## Tests (C)
- e2e/exhibition-images.spec.ts asserts every image paints (naturalWidth > 0) on the exhibition profile. WebGL-free page only.

## Not in this PR
- Fix Sentry tracing so tracesSampleRate:1.0 actually records transactions (currently 0) — deferred.
- Full launch observability plan (Tier 1-3 silent-failure gaps) — deferred.
- Enable Vercel Skew Protection (dashboard toggle) and add NEXT_PUBLIC_SENTRY_DSN to the Preview env — operator actions.