### PR TITLE
Feat/AR-128: Revert serif font to EB Garamond + UI polish pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-art-room",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,4 +1,4 @@
-import { Lato, Geist, Roboto, Lora, Alegreya, Manrope, Caveat } from 'next/font/google'
+import { Lato, EB_Garamond, Geist, Roboto, Lora, Alegreya, Manrope, Caveat } from 'next/font/google'
 import localFont from 'next/font/local'
 
 /**
@@ -36,14 +36,14 @@ export const bodyFont = Lato({
 
 /**
  * Heading font - Used for: h1, h2, h3, h4, h5, h6 and all `*Serif` text
- * (the `--font-serif` token). Current: Lora.
- * To change: Replace Lora with any Google font.
+ * (the `--font-serif` token). Current: EB Garamond.
+ * To change: Replace EB_Garamond with any Google font.
  *
  * `display: 'optional'` — see note on bodyFont. Headings are the most
  * visible font-swap CLS source because heading sizes amplify metric
  * differences between fallback and webfont.
  */
-export const headingFont = Lora({
+export const headingFont = EB_Garamond({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
   variable: '--font-serif',

--- a/src/components/PrintWizard/PrintWizard.module.scss
+++ b/src/components/PrintWizard/PrintWizard.module.scss
@@ -37,7 +37,7 @@
 }
 
 .logo {
-  width: 180px;
+  width: var(--logo-width);
   height: auto;
   color: var(--color-brand);
   overflow: visible;

--- a/src/components/artwork/detail/ArtworkDetail.module.scss
+++ b/src/components/artwork/detail/ArtworkDetail.module.scss
@@ -72,6 +72,7 @@
 .inquireButton {
   margin-top: var(--space-4);
   align-self: flex-start;
+  width: 200px;
 }
 
 .share {

--- a/src/components/checkout/PrintCheckout/PrintCheckout.module.scss
+++ b/src/components/checkout/PrintCheckout/PrintCheckout.module.scss
@@ -26,7 +26,7 @@
 }
 
 .logo {
-  width: 180px;
+  width: var(--logo-width);
   height: auto;
   color: var(--color-brand);
   overflow: visible;

--- a/src/components/checkout/PrintConfirmation/PrintConfirmation.module.scss
+++ b/src/components/checkout/PrintConfirmation/PrintConfirmation.module.scss
@@ -16,7 +16,7 @@
 }
 
 .logo {
-  width: 180px;
+  width: var(--logo-width);
   height: auto;
   color: var(--color-brand);
 }

--- a/src/components/checkout/PrintPayment/PrintPayment.module.scss
+++ b/src/components/checkout/PrintPayment/PrintPayment.module.scss
@@ -22,7 +22,7 @@
 }
 
 .logo {
-  width: 180px;
+  width: var(--logo-width);
   height: auto;
   color: var(--color-brand);
   overflow: visible;

--- a/src/components/contact/Contact.module.scss
+++ b/src/components/contact/Contact.module.scss
@@ -117,12 +117,12 @@
 
 .email {
   font-family: var(--font-serif);
-  font-size: var(--text-xl-mobile);
+  font-size: var(--text-lg-mobile);
   color: var(--color-text-primary);
   text-decoration: none;
 
   @include breakpoint(lg) {
-    font-size: var(--text-2xl);
+    font-size: var(--text-xl);
   }
 
   &:hover {

--- a/src/components/contact/index.tsx
+++ b/src/components/contact/index.tsx
@@ -28,7 +28,9 @@ export const ContactPage = () => {
             <Text as="span" size="xs" className={styles.label}>
               LOCATIONS
             </Text>
-            <Text className={styles.value}>Madrid &nbsp;&nbsp;&nbsp; Vienna</Text>
+            <Text font="serif" className={styles.value}>
+              Madrid &nbsp;&nbsp;&nbsp; Vienna
+            </Text>
           </div>
         </div>
 

--- a/src/components/exhibitions/profile/EnterExhibitionButton.tsx
+++ b/src/components/exhibitions/profile/EnterExhibitionButton.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import { ArrowRight } from 'lucide-react'
-
 import { Button } from '@/components/ui/Button'
-import { ICON_STROKE_WIDTH } from '@/lib/iconConfig'
 
 interface EnterExhibitionButtonProps {
   artistSlug: string
@@ -38,10 +35,10 @@ export const EnterExhibitionButton = ({
     >
       <Button
         variant="primary"
-        size="regularSquared"
+        size="bigSquared"
         label="Enter Virtual Exhibition"
         href={visitUrl}
-        iconLeft={<ArrowRight size={16} strokeWidth={ICON_STROKE_WIDTH} />}
+        icon="arrowRight"
         className={className}
       />
     </div>

--- a/src/components/landing/FeaturedArtists/FeaturedArtists.module.scss
+++ b/src/components/landing/FeaturedArtists/FeaturedArtists.module.scss
@@ -22,6 +22,18 @@
   padding: var(--space-6) 0;
   border-bottom: 1px solid var(--color-border-default);
 
+  // Last visual row carries no divider: the last item (both layouts), and on
+  // the two-column layout also the left item of the final row when present.
+  &:last-child {
+    border-bottom: none;
+  }
+
+  @media (min-width: 1024px) {
+    &:nth-child(odd):nth-last-child(-n + 2) {
+      border-bottom: none;
+    }
+  }
+
   &:hover {
     text-decoration: none;
   }

--- a/src/components/ui/Header/Header.module.scss
+++ b/src/components/ui/Header/Header.module.scss
@@ -32,7 +32,7 @@
 }
 
 .logo {
-  width: 160px;
+  width: var(--logo-width);
   height: auto;
   color: var(--color-brand);
   overflow: visible;

--- a/src/components/ui/InquireSidebar/InquireSidebar.module.scss
+++ b/src/components/ui/InquireSidebar/InquireSidebar.module.scss
@@ -160,7 +160,7 @@
 }
 
 .artworkImage {
-  width: 80px;
+  width: auto;
   height: 80px;
   flex-shrink: 0;
   overflow: hidden;

--- a/src/components/ui/InquireSidebar/InquireSidebar.tsx
+++ b/src/components/ui/InquireSidebar/InquireSidebar.tsx
@@ -310,7 +310,7 @@ export const InquireSidebar = ({ isOpen, onClose, artwork }: InquireSidebarProps
                       alt={artwork.title}
                       width={80}
                       height={80}
-                      style={{ objectFit: 'cover' }}
+                      style={{ height: 80, width: 'auto' }}
                     />
                   </div>
                   <div className={styles.artworkInfo}>

--- a/src/components/ui/Navigation/Navigation.module.scss
+++ b/src/components/ui/Navigation/Navigation.module.scss
@@ -91,7 +91,7 @@
   align-items: center;
 
   svg {
-    width: 180px;
+    width: var(--logo-width);
     height: auto;
     color: var(--color-brand);
   }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -83,6 +83,7 @@
   --color-brand: var(--color-red-50);
   --color-accent: var(--color-blue-50);
   --color-highlight: var(--color-orange-50);
+  --logo-width: 160px; // one knob for the header logo everywhere
 
   // Panels
   --color-surface-elevated: var(--color-gray-15);


### PR DESCRIPTION
- headingFont (--font-serif) back to EB Garamond; Lora stays only as the wall/stencil artistic-text option (--font-wall-lora)
- normalize header logo to one knob: --logo-width (160px) across main header, mobile nav, wizard, checkout, payment, confirmation
- contact page: Madrid/Vienna locations in serif; email one size step smaller on both breakpoints
- "Enter Virtual Exhibition" button upgraded to bigSquared (matches Inquire/Order Print pattern)
- artwork page: Inquire + Order Print buttons fixed at 200px width
- featured artists: no divider under the last visual row (handles 1-col mobile and 2-col desktop incl. odd counts)
- inquire sidebar: thumbnail keeps artwork aspect ratio (80px height, width auto — no more square crop)
- version bump 3.8.6 → 3.8.7